### PR TITLE
chore: let biome-ci biome.json

### DIFF
--- a/.github/workflows/biome-ci.yml
+++ b/.github/workflows/biome-ci.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           version: latest
       - name: Run Biome
-        run: biome ci ./src
+        run: biome ci ./src --config-path=./biome.json
 


### PR DESCRIPTION
## 実装内容
- ignoreに設定したはずのファイルがactionsではignoreされず検証されていたので、
biome-ciがbiome.jsonの設定を拾ってくれるように変更

## スクショ

## issue
close 

## 懸念点
