### PR TITLE
feat: create api which is able to set os name

### DIFF
--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -1,7 +1,7 @@
 import { auth } from "@/src/lib/auth";
 import { prisma } from "@/src/lib/prisma";
 import type { RouteHandler } from "@hono/zod-openapi";
-import type { checkOsNameRoute } from "../routes/user.route";
+import type { checkOsNameRoute, setOsNameRoute } from "../routes/user.route";
 
 export const checkOsNameHandler: RouteHandler<typeof checkOsNameRoute> = async (c) => {
 	const { osName } = c.req.valid("json");
@@ -34,4 +34,43 @@ export const checkOsNameHandler: RouteHandler<typeof checkOsNameRoute> = async (
 	}
 
 	return c.json(null, 200);
+};
+
+export const setOsNameHandler: RouteHandler<typeof setOsNameRoute> = async (c) => {
+	const { osName } = c.req.valid("json");
+
+	const session = await auth.api.getSession({
+		headers: c.req.raw.headers,
+	});
+
+	if (!session?.user?.id) {
+		throw new Error("Unauthorized");
+	}
+
+	const me = await prisma.user.findUnique({
+		where: { id: session.user.id },
+		select: { osName: true },
+	});
+
+	if (!me) {
+		return c.json(null, 404);
+	}
+
+	if (me.osName !== null) {
+		return c.json(null, 400);
+	}
+
+	const exists = await prisma.user.findUnique({ where: { osName } });
+
+	if (exists) {
+		return c.json(null, 409);
+	}
+
+	await prisma.user.update({
+		where: { id: session.user.id },
+		data: { osName },
+		select: { osName: true },
+	});
+
+	return c.json(null, 201);
 };

--- a/src/server/hono.ts
+++ b/src/server/hono.ts
@@ -1,12 +1,14 @@
 import { swaggerUI } from "@hono/swagger-ui";
 //server/hono.ts
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { checkOsNameHandler } from "./controllers/user.controller";
-import { checkOsNameRoute } from "./routes/user.route";
+import { checkOsNameHandler, setOsNameHandler } from "./controllers/user.controller";
+import { checkOsNameRoute, setOsNameRoute } from "./routes/user.route";
 
 export const app = new OpenAPIHono().basePath("/api");
 
-const osApp = new OpenAPIHono().openapi(checkOsNameRoute, checkOsNameHandler);
+const osApp = new OpenAPIHono()
+	.openapi(checkOsNameRoute, checkOsNameHandler)
+	.openapi(setOsNameRoute, setOsNameHandler);
 
 app.route("/", osApp);
 

--- a/src/server/models/user.schema.ts
+++ b/src/server/models/user.schema.ts
@@ -1,18 +1,21 @@
 import { UserSchema } from "@/prisma/prisma/zod";
 import { z } from "@hono/zod-openapi";
 
-export const osNameCheckSchema = UserSchema.pick({
+export const osNameBaseSchema = UserSchema.pick({
 	osName: true,
-})
-	.extend({
-		osName: z
-			.string()
-			.min(2, { message: "OS 名は2文字以上で入力してください。" })
-			.max(10, { message: "OS 名は10文字以下で入力してください。" }),
-	})
-	.openapi({
-		description: "重複チェック対象の OS 名",
-		example: { osName: "yuuta" },
-	});
+}).extend({
+	osName: z
+		.string()
+		.min(2, { message: "OS 名は2文字以上で入力してください。" })
+		.max(10, { message: "OS 名は10文字以下で入力してください。" }),
+});
 
-export type singInSchemaType = z.infer<typeof osNameCheckSchema>;
+export const osNameCheckSchema = osNameBaseSchema.openapi({
+	description: "重複チェック対象の OS 名",
+	example: { osName: "yuuta" },
+});
+
+export const setOsNameSchema = osNameBaseSchema.openapi({
+	description: "ユーザーの OS 名を設定するためのペイロード",
+	example: { osName: "yuuta" },
+});

--- a/src/server/routes/user.route.ts
+++ b/src/server/routes/user.route.ts
@@ -1,10 +1,10 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { osNameCheckSchema } from "../models/user.schema";
+import { osNameCheckSchema, setOsNameSchema } from "../models/user.schema";
 
 export const checkOsNameRoute = createRoute({
 	path: "/os/check-name",
 	method: "post",
-	description: "ユーザー名の設定",
+	description: "ユーザー名の重複チェック",
 	request: {
 		body: {
 			content: {
@@ -16,6 +16,55 @@ export const checkOsNameRoute = createRoute({
 	},
 	responses: {
 		200: {
+			description: "成功",
+			content: {
+				"application/json": {
+					schema: z.null(),
+				},
+			},
+		},
+		400: {
+			description: "不正なリクエスト",
+			content: {
+				"application/json": {
+					schema: z.null(),
+				},
+			},
+		},
+		404: {
+			description: "ユーザーが見つからない",
+			content: {
+				"application/json": {
+					schema: z.null(),
+				},
+			},
+		},
+		409: {
+			description: "重複",
+			content: {
+				"application/json": {
+					schema: z.null(),
+				},
+			},
+		},
+	},
+});
+
+export const setOsNameRoute = createRoute({
+	path: "/user/os-name",
+	method: "post",
+	description: "ユーザー名の設定",
+	request: {
+		body: {
+			content: {
+				"application/json": {
+					schema: setOsNameSchema,
+				},
+			},
+		},
+	},
+	responses: {
+		201: {
 			description: "成功",
 			content: {
 				"application/json": {


### PR DESCRIPTION
## 実装内容
osnameを設定するapiを作成しました。

【確認して欲しいこと】
- 認証した状態で、2文字から10文字以内でosNameを送る（200が返ってくる)
- 再度、osNameを送ると、再設定はできない(400が返ってくる）

api doc: http://localhost:3000/api/doc

## スクショ

## issue
close 

## 懸念点
