### PR TITLE
feat: conntect to api concerning onbo

### DIFF
--- a/src/app/(auth)/enter/callback/welcome/page.tsx
+++ b/src/app/(auth)/enter/callback/welcome/page.tsx
@@ -1,3 +1,17 @@
-export default function Page() {
-	return <div>アカウント完成したよん</div>;
+import WelcomeWrapper from "@/src/components/onboarding/WelcomeWrapper";
+import { auth } from "@/src/lib/auth";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+export default async function Page() {
+	const session = await auth.api.getSession({
+		headers: await headers(),
+	});
+
+	//ログインしてないのならログインページへ
+	if (!session?.user?.id) return redirect("/login");
+	//OSNameが設定されているのなら、それぞれのOSへ
+	if (session.user.osName) redirect(`/os/${session.user.osName}`);
+
+	return <WelcomeWrapper />;
 }

--- a/src/components/onboarding/CreateSuccess.tsx
+++ b/src/components/onboarding/CreateSuccess.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+type Props = {
+	osName: string;
+};
+
+export default function CreateSuccess({ osName }: Props) {
+	return (
+		<div>
+			<p>{osName}できたよ。</p>
+			<Link href={`/os/${osName}`}>here</Link>
+		</div>
+	);
+}

--- a/src/components/onboarding/InputOsNameForm.tsx
+++ b/src/components/onboarding/InputOsNameForm.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Button } from "@/src/components/ui/button";
+import {
+	Form,
+	FormControl,
+	FormDescription,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/src/components/ui/form";
+import { Input } from "@/src/components/ui/input";
+import { hono } from "@/src/lib/hono-client";
+import { osNameBaseSchema } from "@/src/server/models/user.schema";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import type { z } from "zod";
+
+type Props = {
+	handleNextStep: () => void;
+	handleOsNameChange: (osName: string) => void;
+};
+
+export default function InputOsNameForm({ handleNextStep, handleOsNameChange }: Props) {
+	const formSchema = osNameBaseSchema.refine(
+		async (data) => {
+			const { osName } = data;
+
+			const res = await hono.api.os["check-name"].$post({
+				json: { osName },
+			});
+
+			return res.status === 200;
+		},
+		{
+			message: "このOS名はすでに使われています",
+			path: ["osName"],
+		},
+	);
+
+	const form = useForm<z.infer<typeof formSchema>>({
+		resolver: zodResolver(formSchema),
+		defaultValues: {
+			osName: "",
+		},
+	});
+
+	const onSubmit = async (data: z.infer<typeof formSchema>) => {
+		const { osName } = data;
+
+		const res = await hono.api.user["os-name"].$post({
+			json: { osName },
+		});
+
+		if (res.status === 201) {
+			handleOsNameChange(osName);
+			handleNextStep();
+		}
+	};
+
+	return (
+		<Form {...form}>
+			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+				<FormField
+					control={form.control}
+					name="osName"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>OS name</FormLabel>
+							<FormControl>
+								<Input placeholder="shadcn" {...field} />
+							</FormControl>
+							<FormDescription>This is your OS name.</FormDescription>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<Button type="submit">Submit</Button>
+			</form>
+		</Form>
+	);
+}

--- a/src/components/onboarding/WelcomeWrapper.tsx
+++ b/src/components/onboarding/WelcomeWrapper.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { set } from "date-fns";
+import { useState } from "react";
+import CreateSuccess from "./CreateSuccess";
+import InputOsNameForm from "./InputOsNameForm";
+
+export default function WelcomeWrapper() {
+	const [step, setStep] = useState(1);
+	const [osName, setOsName] = useState("");
+
+	const handleNextStep = () => setStep(2);
+	const handleOsNameChange = (name: string) => setOsName(name);
+
+	return (
+		<>
+			{step === 1 && (
+				<InputOsNameForm handleOsNameChange={handleOsNameChange} handleNextStep={handleNextStep} />
+			)}
+			{step === 2 && <CreateSuccess osName={osName} />}
+		</>
+	);
+}

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -10,8 +10,11 @@ export const env = createEnv({
 		GOOGLE_CLIENT_ID: z.string(),
 		GOOGLE_CLIENT_SECRET: z.string(),
 	},
-	client: {},
+	client: {
+		NEXT_PUBLIC_APP_URL: z.string().url(),
+	},
 	runtimeEnv: {
+		NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
 		DATABASE_URL: process.env.DATABASE_URL,
 		DIRECT_URL: process.env.DIRECT_URL,
 		BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,6 +7,13 @@ export const auth = betterAuth({
 	database: prismaAdapter(prisma, {
 		provider: "postgresql",
 	}),
+	user: {
+		additionalFields: {
+			osName: {
+				type: "string",
+			},
+		},
+	},
 	socialProviders: {
 		google: {
 			clientId: env.GOOGLE_CLIENT_ID,

--- a/src/lib/hono-client.ts
+++ b/src/lib/hono-client.ts
@@ -1,0 +1,6 @@
+//lib/hono.ts
+import type { AppType } from "@/src/server/hono";
+import { hc } from "hono/client";
+import { env } from "../env.mjs";
+
+export const hono = hc<AppType>(env.NEXT_PUBLIC_APP_URL);

--- a/src/server/hono.ts
+++ b/src/server/hono.ts
@@ -10,7 +10,7 @@ const osApp = new OpenAPIHono()
 	.openapi(checkOsNameRoute, checkOsNameHandler)
 	.openapi(setOsNameRoute, setOsNameHandler);
 
-app.route("/", osApp);
+const route = app.route("/", osApp);
 
 app
 	.doc("/specification", {
@@ -19,4 +19,5 @@ app
 	})
 	.get("/doc", swaggerUI({ url: "/api/specification" }));
 
+export type AppType = typeof route;
 export default app;

--- a/src/server/models/user.schema.ts
+++ b/src/server/models/user.schema.ts
@@ -7,7 +7,10 @@ export const osNameBaseSchema = UserSchema.pick({
 	osName: z
 		.string()
 		.min(2, { message: "OS 名は2文字以上で入力してください。" })
-		.max(10, { message: "OS 名は10文字以下で入力してください。" }),
+		.max(10, { message: "OS 名は10文字以下で入力してください。" })
+		.regex(/^[A-Za-z]+$/, {
+			message: "OS 名は半角アルファベットのみで入力してください。",
+		}),
 });
 
 export const osNameCheckSchema = osNameBaseSchema.openapi({


### PR DESCRIPTION
## 実装内容
- onboardingに関するapiをフロントと繋ぎました。
- os nameは半角の英文字しか受け付けない実装に変更しました。

.envに以下を書き足してください。

```
//.env
NEXT_PUBLIC_APP_URL=http://localhost:3000
```

【チェックして欲しいこと】
1. [http://localhost:3000/login](http://localhost:3000/login)にアクセスし、ログイン
2. 以下のOS nameを試してください。
- 日本語入力（バリデーションで弾かれる）
- `yuuta`と入力（すでに使われているのでバリデーションに弾かれる）
- 2文字から10文字以内で正しいものを入力
3. アカウントが作成され、`here`を押すと、自身のosに遷移するかどうか。
4. 再度[http://localhost:3000/login](http://localhost:3000/login)にアクセスし、ログインすると、直接自分のosに遷移するか。

## スクショ

## issue
close 

## 懸念点
