### PR TITLE
feat: create middleware

### DIFF
--- a/src/app/os/[osName]/page.tsx
+++ b/src/app/os/[osName]/page.tsx
@@ -3,7 +3,7 @@ import { hono } from "@/src/lib/hono-client";
 import { headers } from "next/headers";
 
 export default async function Page({ params }: { params: { osName: string } }) {
-	const res = await hono.api.desktop[":osName"].$get(
+	const res = await hono.api.desktop[":osName"].state.$get(
 		{
 			param: {
 				osName: params.osName,

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -9,6 +9,8 @@ export const env = createEnv({
 		BETTER_AUTH_URL: z.string().url(),
 		GOOGLE_CLIENT_ID: z.string(),
 		GOOGLE_CLIENT_SECRET: z.string(),
+		API_DOC_BASIC_AUTH_USER: z.string(),
+		API_DOC_BASIC_AUTH_PASS: z.string(),
 	},
 	client: {
 		NEXT_PUBLIC_APP_URL: z.string().url(),
@@ -21,5 +23,7 @@ export const env = createEnv({
 		BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
 		GOOGLE_CLIENT_ID: process.env.GITHUB_CLIENT_ID,
 		GOOGLE_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET,
+		API_DOC_BASIC_AUTH_USER: process.env.API_DOC_BASIC_AUTH_USER,
+		API_DOC_BASIC_AUTH_PASS: process.env.API_DOC_BASIC_AUTH_PASS,
 	},
 });

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -1,21 +1,17 @@
 import { auth } from "@/src/lib/auth";
 import { prisma } from "@/src/lib/prisma";
 import type { RouteHandler } from "@hono/zod-openapi";
+import type { WithAuthenticatedRequest } from "../middleware/authMIddleware";
 import type { checkOsNameRoute, setOsNameRoute } from "../routes/user.route";
 
-export const checkOsNameHandler: RouteHandler<typeof checkOsNameRoute> = async (c) => {
+export const checkOsNameHandler: RouteHandler<
+	typeof checkOsNameRoute,
+	WithAuthenticatedRequest
+> = async (c) => {
 	const { osName } = c.req.valid("json");
 
-	const session = await auth.api.getSession({
-		headers: c.req.raw.headers,
-	});
-
-	if (!session?.user?.id) {
-		throw new Error("Unauthorized");
-	}
-
 	const me = await prisma.user.findUnique({
-		where: { id: session.user.id },
+		where: { id: c.var.userId },
 		select: { osName: true },
 	});
 
@@ -36,19 +32,14 @@ export const checkOsNameHandler: RouteHandler<typeof checkOsNameRoute> = async (
 	return c.json(null, 200);
 };
 
-export const setOsNameHandler: RouteHandler<typeof setOsNameRoute> = async (c) => {
+export const setOsNameHandler: RouteHandler<
+	typeof setOsNameRoute,
+	WithAuthenticatedRequest
+> = async (c) => {
 	const { osName } = c.req.valid("json");
 
-	const session = await auth.api.getSession({
-		headers: c.req.raw.headers,
-	});
-
-	if (!session?.user?.id) {
-		throw new Error("Unauthorized");
-	}
-
 	const me = await prisma.user.findUnique({
-		where: { id: session.user.id },
+		where: { id: c.var.userId },
 		select: { osName: true },
 	});
 
@@ -67,7 +58,7 @@ export const setOsNameHandler: RouteHandler<typeof setOsNameRoute> = async (c) =
 	}
 
 	await prisma.user.update({
-		where: { id: session.user.id },
+		where: { id: c.var.userId },
 		data: {
 			osName,
 			desktop: {

--- a/src/server/hono.ts
+++ b/src/server/hono.ts
@@ -1,6 +1,10 @@
 //server/hono.ts
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { Scalar } from "@scalar/hono-api-reference";
+import type { Env } from "hono";
+import { basicAuth } from "hono/basic-auth";
+import { except } from "hono/combine";
+import { env } from "../env.mjs";
 import {
 	getDesktopStateHandler,
 	updateDesktopBackgroundHandler,
@@ -8,6 +12,7 @@ import {
 	updateDesktopVisibilityHandler,
 } from "./controllers/os.controller";
 import { checkOsNameHandler, setOsNameHandler } from "./controllers/user.controller";
+import { type WithAuthenticatedRequest, authMiddleware } from "./middleware/authMIddleware";
 import {
 	getDesktopStateRoute,
 	updateBackgroundRoute,
@@ -18,7 +23,7 @@ import { checkOsNameRoute, setOsNameRoute } from "./routes/user.route";
 
 export const app = new OpenAPIHono().basePath("/api");
 
-const osApp = new OpenAPIHono()
+const osApp = new OpenAPIHono<Env & WithAuthenticatedRequest>()
 	.openapi(checkOsNameRoute, checkOsNameHandler)
 	.openapi(setOsNameRoute, setOsNameHandler)
 	.openapi(getDesktopStateRoute, getDesktopStateHandler)
@@ -26,14 +31,22 @@ const osApp = new OpenAPIHono()
 	.openapi(updateVisibilityRoute, updateDesktopVisibilityHandler)
 	.openapi(updateBackgroundRoute, updateDesktopBackgroundHandler);
 
-const route = app.route("/", osApp);
-
 app
 	.doc("/specification", {
 		openapi: "3.0.0",
 		info: { title: "Bolt New Hackathon", version: "1.0.0" },
 	})
+	.use("/doc/*", async (c, next) => {
+		const auth = basicAuth({
+			username: env.API_DOC_BASIC_AUTH_USER,
+			password: env.API_DOC_BASIC_AUTH_PASS,
+		});
+		return auth(c, next);
+	})
 	.get("/doc", Scalar({ url: "/api/specification" }));
+
+app.use(except("/api/desktop/:osName/state", authMiddleware));
+const route = app.route("/", osApp);
 
 export type AppType = typeof route;
 export default app;

--- a/src/server/middleware/authMIddleware.ts
+++ b/src/server/middleware/authMIddleware.ts
@@ -1,0 +1,23 @@
+import { auth } from "@/src/lib/auth";
+import type { Session } from "better-auth";
+import type { MiddlewareHandler } from "hono";
+import { createMiddleware } from "hono/factory";
+import { HTTPException } from "hono/http-exception";
+
+export type WithAuthenticatedRequest = { Variables: { userId: Session["userId"] } };
+
+export const authMiddleware: MiddlewareHandler<WithAuthenticatedRequest> = createMiddleware(
+	async (c, next) => {
+		const session = await auth.api.getSession({
+			headers: c.req.raw.headers,
+		});
+
+		if (!session?.user?.id) {
+			throw new HTTPException(401, { message: "認証が必要です。" });
+		}
+
+		c.set("userId", session.user.id);
+
+		await next();
+	},
+);

--- a/src/server/routes/os.route.ts
+++ b/src/server/routes/os.route.ts
@@ -8,7 +8,7 @@ import {
 import { osNameBaseSchema } from "../models/user.schema";
 
 export const getDesktopStateRoute = createRoute({
-	path: "/desktop/{osName}",
+	path: "/desktop/{osName}/state",
 	method: "get",
 	description: "デスクトップの状態を取得",
 	request: {


### PR DESCRIPTION
## 実装内容
- scalarにbasic認証を実装
[https://www.notion.so/env-20c1977f05d980c7b7c7e95727af98d2](https://www.notion.so/env-20c1977f05d980c7b7c7e95727af98d2)に`.env`情報は追記。
- 認証ガードをmiddlewareに移行
-  デスクトップの情報を返すapiを`/api/desktop/{osName}/state`にリネーム

## スクショ

## issue
close 

## 懸念点
