### PR TITLE
feat: add 403 Forbidden for unauthorized desktop access

### DIFF
--- a/src/server/controllers/os.controller.ts
+++ b/src/server/controllers/os.controller.ts
@@ -34,14 +34,18 @@ export const getDesktopStateHandler: RouteHandler<
 		return c.json(null, 404);
 	}
 
-	const rawJson = userWithDesktop.desktop.state;
-	const parsedState = stateSchema.parse(rawJson);
-
 	const session = await auth.api.getSession({
 		headers: c.req.raw.headers,
 	});
 
 	const isEdit = session?.user.id === userWithDesktop.id;
+
+	if (!userWithDesktop.desktop.isPublic && !isEdit) {
+		return c.json(null, 403);
+	}
+
+	const rawJson = userWithDesktop.desktop.state;
+	const parsedState = stateSchema.parse(rawJson);
 
 	const result = {
 		state: parsedState,

--- a/src/server/routes/os.route.ts
+++ b/src/server/routes/os.route.ts
@@ -27,6 +27,10 @@ export const getDesktopStateRoute = createRoute({
 				},
 			},
 		},
+		403: {
+			description: "権限がありません。",
+			content: { "application/json": { schema: z.null() } },
+		},
 	},
 });
 


### PR DESCRIPTION
## 実装内容
- ログインしているユーザーとos作成者が同じでなく、非公開状態の時に権限がありません`403`を返すように修正。

## スクショ

## issue
close 

## 懸念点
フロントエンドで`403`をチェックして、「権限がありません」とか書いてもらえると良いかもです。
