### PR TITLE
feat: cant editable user display

### DIFF
--- a/src/components/MacosDesktop.tsx
+++ b/src/components/MacosDesktop.tsx
@@ -92,6 +92,9 @@ export default function MacosDesktop({ desktop, osName }: Props) {
 	// public or private
 	const [isPublic, setIsPublic] = useState(false);
 
+	// isEdit
+	const isEdit = desktop.isEdit ?? false;
+
 	const dragSourceRef = useRef<GridPosition | null>(null);
 
 	// Update time every second
@@ -186,6 +189,7 @@ export default function MacosDesktop({ desktop, osName }: Props) {
 	};
 
 	const handleDragStart = (e: React.DragEvent, appId: string) => {
+		if (!isEdit) return;
 		setDraggedApp(appId);
 		const position = appPositions.get(appId);
 		if (position) {
@@ -222,6 +226,7 @@ export default function MacosDesktop({ desktop, osName }: Props) {
 	};
 
 	const handleDrop = (e: React.DragEvent, targetRow: number, targetCol: number) => {
+		if (!isEdit) return;
 		e.preventDefault();
 
 		if (!draggedApp || !dragSourceRef.current) return;
@@ -263,6 +268,7 @@ export default function MacosDesktop({ desktop, osName }: Props) {
 	};
 
 	const handleRightClick = (e: React.MouseEvent, row: number, col: number) => {
+		if (isEdit === false) return;
 		e.preventDefault();
 		e.stopPropagation();
 		const existingApp = getAppAtPosition(row, col);
@@ -1013,7 +1019,7 @@ export default function MacosDesktop({ desktop, osName }: Props) {
 					>
 						{app && (
 							<div
-								draggable
+								draggable={isEdit}
 								onDragStart={(e) => handleDragStart(e, app.id)}
 								onDragEnd={handleDragEnd}
 								onClick={() => handleAppClick(app)}
@@ -1066,6 +1072,7 @@ export default function MacosDesktop({ desktop, osName }: Props) {
 				isPublic={isPublic}
 				setIsPublic={setIsPublic}
 				osName={osName}
+				isEditable={isEdit}
 			/>
 
 			{/* Desktop grid */}
@@ -1273,6 +1280,7 @@ export default function MacosDesktop({ desktop, osName }: Props) {
 						<MemoWindow
 							key={window.id}
 							window={window}
+							isEditable={isEdit}
 							onClose={() => closeMemoWindow(window.id)}
 							onMinimize={() => minimizeMemoWindow(window.id)}
 							onContentChange={(content) => updateMemoContent(window.id, content)}
@@ -1521,7 +1529,7 @@ export default function MacosDesktop({ desktop, osName }: Props) {
 						))}
 				</div>
 			</div>
-			{showDesktopSaveBtn && (
+			{showDesktopSaveBtn && isEdit && (
 				<div className="fixed right-6 bottom-6 z-50 rounded-md bg-white p-4 text-black text-sm shadow-lg transition">
 					<p>Do you want to save changes?</p>
 					<Button size="sm" className="mt-2" onClick={handleSaveDesktop}>

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -11,6 +11,7 @@ type Props = {
 	isPublic: boolean;
 	setIsPublic: (isPublic: boolean) => void;
 	osName: string;
+	isEditable: boolean;
 };
 
 export const MenuBar = ({
@@ -21,6 +22,7 @@ export const MenuBar = ({
 	isPublic,
 	setIsPublic,
 	osName,
+	isEditable = false,
 }: Props) => {
 	const formatTime = (date: Date) => {
 		return date.toLocaleTimeString("en-US", {
@@ -47,17 +49,21 @@ export const MenuBar = ({
 						<p className="mb-1 text-sm"> {osName ? osName : "🍎"}</p>
 					</div>
 					{/* Background Selector */}
-					<BackgroundSelector
-						onBackgroundChange={onBackgroundChange}
-						currentBackground={background}
-						setBackground={setBackground}
-					/>
+					{isEditable && (
+						<BackgroundSelector
+							onBackgroundChange={onBackgroundChange}
+							currentBackground={background}
+							setBackground={setBackground}
+						/>
+					)}
 				</div>
 				<div className="flex items-center space-x-3 text-sm text-white">
 					{/* public or private toggle */}
-					<div className="flex items-center">
-						<PublicSelector isPublic={isPublic} setIsPublic={setIsPublic} />
-					</div>
+					{isEditable && (
+						<div className="flex items-center">
+							<PublicSelector isPublic={isPublic} setIsPublic={setIsPublic} />
+						</div>
+					)}
 
 					{/* Time */}
 					<div className="flex items-center space-x-1">

--- a/src/components/window/MemoWindow.tsx
+++ b/src/components/window/MemoWindow.tsx
@@ -3,7 +3,6 @@ import StarterKit from "@tiptap/starter-kit";
 import { useEffect, useState } from "react";
 import type { MemoWindowType } from "../../types/desktop";
 import TiptapEditor from "../TiptapEditor";
-import { Button } from "../ui/button";
 
 export function MemoWindow({
 	window,
@@ -13,6 +12,7 @@ export function MemoWindow({
 	onBringToFront,
 	onPositionChange,
 	onSizeChange,
+	isEditable = false,
 }: {
 	window: MemoWindowType;
 	onClose: () => void;
@@ -21,6 +21,7 @@ export function MemoWindow({
 	onBringToFront: () => void;
 	onPositionChange: (position: { x: number; y: number }) => void;
 	onSizeChange: (size: { width: number; height: number }) => void;
+	isEditable: boolean;
 }) {
 	const [isDragging, setIsDragging] = useState(false);
 	const [isResizing, setIsResizing] = useState(false);
@@ -35,6 +36,7 @@ export function MemoWindow({
 	const editor = useEditor({
 		extensions: [StarterKit],
 		content: window.content,
+		editable: isEditable,
 		editorProps: {
 			attributes: {
 				class:


### PR DESCRIPTION
## 実装内容
- ユーザーが自身のデスクトップを見たときとユーザーが他のユーザーのデスクトップを見たときの表示を変えた(下記の状態)
  - background変更
  - 公開、非公開
  - memoへの書き込み
  - 右クリックの可否
    - デスクトップ上での右クリ
    - アプリの上での右クリ
  - アプリの移動
## スクショ
## issue
close 

## 懸念点
