### PR TITLE
fix: desktop state zod

### DIFF
--- a/src/app/os/[osName]/page.tsx
+++ b/src/app/os/[osName]/page.tsx
@@ -16,10 +16,17 @@ export default async function Page({ params }: { params: { osName: string } }) {
 			},
 		},
 	);
-	const data = await res.json();
-	if (res.status === 404 || !data) {
+
+	if (res.status === 404) {
 		return <div>No desktop information</div>;
 	}
+
+	if (res.status === 403) {
+		return <div>This OS is not available for viewing.</div>;
+	}
+
+	const data = await res.json();
+
 	return (
 		<>
 			<MacosDesktop desktop={data} osName={params.osName} />

--- a/src/components/MacosDesktop.tsx
+++ b/src/components/MacosDesktop.tsx
@@ -124,6 +124,11 @@ export default function MacosDesktop({ desktop, osName }: Props) {
 			setOriginalAppPositions(positionsMap);
 			setApps(responseApps);
 			setOriginalApps(responseApps);
+
+			// folderContents の初期化
+			const fcMap = new Map<string, string[]>(Object.entries(desktop.state.folderContents));
+			setFolderContents(fcMap);
+
 			setPositionsInitialized(true);
 			setIsPublic(desktop.isPublic);
 			if (desktop.background) {

--- a/src/components/lp/Hero.tsx
+++ b/src/components/lp/Hero.tsx
@@ -592,7 +592,8 @@ export default function Hero({ changeScrollY, scrollY }: Props) {
 					<div className="pointer-events-none absolute inset-0">
 						{heroIcons.map(({ Icon, x, y, color, rotation, id, name }, index) => (
 							<div
-								key={id}
+								// biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+								key={index}
 								className={`absolute rounded-2xl border border-gray-100 bg-white p-4 shadow-lg transition-all duration-300 hover:shadow-xl ${
 									id === "notepad" && isAnimating && cursorPosition.x > window.innerWidth * 0.8
 										? "ring-4 ring-blue-400 ring-opacity-75"


### PR DESCRIPTION
## 実装内容
- zodのスキーマを変更し、folderContentをサーバーで受け取れるように
- フロントでfolderContentを受け取り初期化
- lpのHero要素でのmapのkeyエラーを解消
- desktop/stateの返り値が403の際に権限エラーを表示

## スクショ

## issue
close 

## 懸念点
