### PR TITLE
fix: able to get current user info by get-desktop-api

### DIFF
--- a/src/server/controllers/os.controller.ts
+++ b/src/server/controllers/os.controller.ts
@@ -53,6 +53,9 @@ export const getDesktopStateHandler: RouteHandler<
 		isPublic: userWithDesktop.desktop.isPublic,
 		background: userWithDesktop.desktop.background,
 		isEdit,
+		currentUsername: session?.user.name ?? null,
+		currentUserOsName: session?.user.osName ?? null,
+		currentUserIcon: session?.user.image ?? null,
 	};
 
 	return c.json(result, 200);
@@ -83,20 +86,20 @@ export const updateDesktopStateHandler: RouteHandler<
 	}
 
 	//prismaでjsonの中を型付けできないのでここで検証する必要があるのかよ！
-	const rawJson = desktop.state;
-	const parsedState = stateSchema.parse(rawJson);
+	// const rawJson = desktop.state;
+	// const parsedState = stateSchema.parse(rawJson);
 
-	const result = {
-		state: parsedState,
-		isPublic: desktop.isPublic,
-		background: desktop.background,
-		isEdit: true,
-	};
+	// const result = {
+	//   state: parsedState,
+	//   isPublic: desktop.isPublic,
+	//   background: desktop.background,
+	//   isEdit: true,
+	// };
 
 	//cacheを更新
 	revalidateTag("desktop");
 
-	return c.json(result, 200);
+	return c.json(null, 200);
 };
 
 export const updateDesktopVisibilityHandler: RouteHandler<

--- a/src/server/models/os.schema.ts
+++ b/src/server/models/os.schema.ts
@@ -150,6 +150,9 @@ export const desktopStateSchema = z
 		state: stateSchema,
 		//編集ができるかどうか
 		isEdit: z.boolean(),
+		currentUserOsName: z.string().nullable(),
+		currentUsername: z.string().nullable(),
+		currentUserIcon: z.string().url().nullable(),
 	})
 	.extend(isPublicSchema.shape)
 	.extend(backgroundSchema.shape);

--- a/src/server/routes/os.route.ts
+++ b/src/server/routes/os.route.ts
@@ -52,7 +52,7 @@ export const updateDesktopStateRoute = createRoute({
 	responses: {
 		200: {
 			description: "更新成功",
-			content: { "application/json": { schema: desktopStateSchema } },
+			content: { "application/json": { schema: z.null() } },
 		},
 		404: {
 			description: "デスクトップ情報が見つかりませんでした。",


### PR DESCRIPTION
## 実装内容
- desktopの状態を取得するapiに認証中のユーザー情報を含めて、返却
- desktopの状態を更新するapiの返り値をnull

## スクショ

## issue
close 

## 懸念点
